### PR TITLE
Change py to python For Start.bat

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,1 +1,1 @@
-py main.py
+python main.py


### PR DESCRIPTION
Most people Have Prefix python Some Have Both.
A lot of people don't have the `py` prefix unless they are on windows.
`python` is the standard prefix.
There.
